### PR TITLE
fix django.utils.importlib deprecated warning

### DIFF
--- a/django_jenkins/tasks/with_coverage.py
+++ b/django_jenkins/tasks/with_coverage.py
@@ -2,7 +2,7 @@ import warnings
 import os
 import sys
 from django.conf import settings
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 def default_coverage_config():


### PR DESCRIPTION
django.utils.importlib will be removed in Django 1.9 and can be safely replaced with pythons importlib that is available since python 2.7